### PR TITLE
fix(allowHidden): set this flag to allow the functor to run

### DIFF
--- a/src/link.js
+++ b/src/link.js
@@ -5,6 +5,11 @@ const { keys } = Object;
 const makeMap = (...args) => new Map(...args);
 
 export const makeEvaluateLinker = (evaluator, instanceCache = new Map()) => {
+  const tolerantEvaluator = (src, endowments, options = {}) => {
+    // Our sources have been already rewritten, so allow the hidden identifiers.
+    const tolerantOptions = { ...options, allowHidden: true };
+    return evaluator(src, endowments, tolerantOptions);
+  };
   const linker = {
     // Instantiation phase produces a linked module instance. A module
     // instance is linked when its importNS is populated with linked
@@ -14,7 +19,7 @@ export const makeEvaluateLinker = (evaluator, instanceCache = new Map()) => {
       const linkedInstance = makeModuleInstance(
         linkageRecord,
         linkedImportNS,
-        evaluator,
+        tolerantEvaluator,
         preEndowments,
       );
       instanceCache.set(linkageRecord.moduleId, linkedInstance);

--- a/test/test-link.js
+++ b/test/test-link.js
@@ -5,7 +5,13 @@ import { makeEvaluateLinker } from '../src';
 
 test('evaluate linker', async t => {
   try {
-    const rootLinker = makeEvaluateLinker(evaluate);
+    const assertEvaluate = (src, endowments, options = {}) => {
+      if (!options.allowHidden) {
+        throw TypeError('allowHidden is not set');
+      }
+      return evaluate(src, endowments, options);
+    };
+    const rootLinker = makeEvaluateLinker(assertEvaluate);
     const linkageMap = new Map([
       [
         'https://www.example.com/foo/abc',


### PR DESCRIPTION
I'm willing to entertain other ways of fixing this, but given the already-tight coupling between make-importer and transform-module, this may be the best way.

Closes #37