### PR TITLE
Fix esm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "eslint-config-prettier": "^6.0.0",
     "eslint-plugin-import": "^2.18.2",
     "eslint-plugin-prettier": "^3.1.0",
+    "esm": "^3.2.5",
     "node-fetch": "^2.6.0",
     "object-inspect": "^1.7.0",
     "prettier": "^1.18.2",
@@ -31,9 +32,6 @@
     "tape": "^4.11.0",
     "tape-promise": "^4.0.0",
     "test262-parser": "^2.2.0"
-  },
-  "dependencies": {
-    "esm": "^3.2.5"
   },
   "keywords": [],
   "files": [


### PR DESCRIPTION
`esm` is not a runtime dependency (the code using make-importer should make that decision).